### PR TITLE
Fixed panic: unaligned 64-bit atomic operation on 32bit arm systems

### DIFF
--- a/lib/relay/relay.go
+++ b/lib/relay/relay.go
@@ -33,6 +33,7 @@ const (
 )
 
 type Relay struct {
+	stats         		RelayStats
 	Group               *net.UDPAddr
 	IfiRecvList         []*net.Interface
 	IfiSendList         []*net.Interface
@@ -49,7 +50,6 @@ type Relay struct {
 
 	running       atomic.Value // type: chan struct{}
 	mcastListener atomic.Value // type: *packetConn
-	stats         RelayStats
 }
 
 func (r *Relay) setRunning(v chan struct{}) {


### PR DESCRIPTION
On 32-bit arm system there is a crash:

panic: unaligned 64-bit atomic operation

goroutine 52 [running]:
internal/runtime/atomic.panicUnaligned()
	/usr/local/go/src/internal/runtime/atomic/unaligned.go:8 +0x24
internal/runtime/atomic.Xadd64(0x2ee20cc, 0x1)
	/usr/local/go/src/internal/runtime/atomic/atomic_arm.s:318 +0x14
github.com/packetspace/sedire/lib/relay.(*Relay).listenMulticast(0x2ee2008)
	/sedire/lib/relay/relay.go:228 +0xb74
github.com/packetspace/sedire/lib/relay.(*Relay).Run(0x2ee2008)
	/sedire/lib/relay/relay.go:330 +0x198
created by github.com/packetspace/sedire/lib/relay.(*Relay).Start in goroutine 1
	/sedire/lib/relay/relay.go:351 +0x58

This commit reorders 'stats' element of the Relay struct in order to mitigate the error.